### PR TITLE
Add GitHub actions workflow for offering pre-built versions of rs-dml binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
           - target: x86_64-pc-windows-gnu
             archive: zip
           - target: x86_64-unknown-linux-musl
-            archive: tar.gz tar.xz tar.zst
+            archive: tar.gz
           - target: x86_64-apple-darwin
             archive: zip
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+# .github/workflows/release.yml
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  release:
+    name: release ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-pc-windows-gnu
+            archive: zip
+          - target: x86_64-unknown-linux-musl
+            archive: tar.gz tar.xz tar.zst
+          - target: x86_64-apple-darwin
+            archive: zip
+    steps:
+      - uses: actions/checkout@master
+      - name: Compile and release
+        uses: rust-build/rust-build.action@v1.4.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          RUSTTARGET: ${{ matrix.target }}
+          ARCHIVE_TYPES: ${{ matrix.archive }}


### PR DESCRIPTION
Hello! Recently I wanted to try out your [IDARustDemangler](https://github.com/timetravelthree/IDARustDemangler) plugin, and I thought it would be good if the dependency it had, `rs-dml`, offered prebuilt binaries so that people who wished to try the plugin did not have to install the Rust toolchain on their machines.

This PR contributes a very simple GitHub workflow that will run upon creating a GitHub release, build binaries for the `x86_64-pc-windows-gnu`, `x86_64-unknown-linux-musl`, and `x86_64-apple-darwin` targets, and attach the binaries to the GitHub release.

It uses the [rust-build/rust-build.action](https://github.com/rust-build/rust-build.action) GitHub action; the workflow is pretty much a copy-paste of one of the examples in the README of that repository.

You can see an example of the builds this workflow produces in my test release, in my fork of the FTLRustDemangler repository: https://github.com/cxiao/FTLRustDemangler/releases/tag/v0.1

Thank you for creating the project! Let me know if you have questions.